### PR TITLE
Fix renewal scheduler crash that prevented app window from opening

### DIFF
--- a/src/main/scheduler.ts
+++ b/src/main/scheduler.ts
@@ -7,9 +7,21 @@ const REMINDER_DAYS = [120, 90, 60, 30]
 const NOTIFIED_KEY_PREFIX = 'reminder_sent_'
 
 export function startScheduler(): void {
-  // Run once on startup and then daily at 9 AM
-  checkRenewals()
-  cron.schedule('0 9 * * *', checkRenewals)
+  // Run once on startup and then daily at 9 AM.
+  // Wrap in try/catch so a scheduler failure can never abort app startup
+  // (this callback runs inside app.whenReady().then, which skips createWindow if it throws).
+  try {
+    checkRenewals()
+  } catch (err) {
+    console.error('[scheduler] initial checkRenewals failed:', err)
+  }
+  cron.schedule('0 9 * * *', () => {
+    try {
+      checkRenewals()
+    } catch (err) {
+      console.error('[scheduler] scheduled checkRenewals failed:', err)
+    }
+  })
 }
 
 function checkRenewals(): void {
@@ -47,7 +59,7 @@ function checkRenewals(): void {
       // Mark as sent
       db.prepare(
         "INSERT INTO app_settings (key, value) VALUES (?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
-      ).run(notifyKey, '1')
+      ).run(notifyKey)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fix `RangeError: Too many parameter values were provided` thrown from `checkRenewals` on startup. The `INSERT INTO app_settings` had one `?` placeholder (value is set by `datetime('now')`) but the code passed two bind values — better-sqlite3 rejected it.
- Because `startScheduler()` runs inside `app.whenReady().then(...)` before `createWindow()` in `src/main/index.ts`, the unhandled rejection skipped window creation entirely and the app appeared to "not load".
- Wrap the startup and cron invocations in `try/catch` so any future scheduler bug can never block app startup again.

## Test plan

- [ ] `npm run dev` — no `UnhandledPromiseRejectionWarning` in console
- [ ] Electron window opens and Dashboard renders
- [ ] With a contract whose `end_date` is 25-35 days out and `status = 'active'`, the 30-day reminder notification fires once and the `app_settings` row `reminder_sent_<id>_30` contains an ISO timestamp in `value` (not the literal `"1"`)
- [ ] Restart — the same contract does not re-notify (proves the mark-as-sent write succeeded)